### PR TITLE
ENH gtgram:  add `f_max` parameter

### DIFF
--- a/src/gammatone/filters.py
+++ b/src/gammatone/filters.py
@@ -56,7 +56,7 @@ def erb_space(low_freq=DEFAULT_LOW_FREQ, high_freq=DEFAULT_HIGH_FREQ, num=DEFAUL
     return erb_point(low_freq, high_freq, np.arange(1, num + 1) / num)
 
 
-def centre_freqs(fs, num_freqs, cutoff):
+def centre_freqs(fs, num_freqs, cutoff, f_max=None):
     """
     Calculates an array of centre frequencies (for :func:`make_erb_filters`)
     from a sampling frequency, lower cutoff frequency and the desired number of
@@ -66,9 +66,12 @@ def centre_freqs(fs, num_freqs, cutoff):
     :param num_freqs: number of centre frequencies to calculate
     :type num_freqs: int
     :param cutoff: lower cutoff frequency
+    :param f_max: upper cutoff frequency (default ``fs / 2``)
     :return: same as :func:`erb_space`
     """
-    return erb_space(cutoff, fs / 2, num_freqs)
+    if f_max is None:
+        f_max = fs / 2
+    return erb_space(cutoff, f_max, num_freqs)
 
 
 def make_erb_filters(fs, centre_freqs, width=1.0):

--- a/src/gammatone/gtgram.py
+++ b/src/gammatone/gtgram.py
@@ -48,7 +48,7 @@ def gtgram(wave, fs, window_time, hop_time, channels, f_min, f_max=None):
     """
     Calculate a spectrogram-like time frequency magnitude array based on
     gammatone subband filters. The waveform ``wave`` (at sample rate ``fs``) is
-    passed through an multi-channel gammatone auditory model filterbank, with
+    passed through a multi-channel gammatone auditory model filterbank, with
     lowest frequency ``f_min`` and highest frequency ``f_max``. The outputs of
     each band then have their energy integrated over windows of ``window_time``
     seconds, advancing by ``hop_time`` secs for successive columns. These
@@ -61,7 +61,7 @@ def gtgram(wave, fs, window_time, hop_time, channels, f_min, f_max=None):
     xe = gtgram_xe(wave, fs, channels, f_min, f_max)
 
     nwin, hop_samples, ncols = gtgram_strides(fs, window_time, hop_time, xe.shape[1])
-    channels, ncols = int(channels), int(ncols)  # typing fro some compatibility reasons
+    channels, ncols = int(channels), int(ncols)  # typing for some compatibility reasons
     y = np.zeros((channels, ncols))
 
     for cnum in range(ncols):

--- a/src/gammatone/gtgram.py
+++ b/src/gammatone/gtgram.py
@@ -35,16 +35,16 @@ def gtgram_strides(fs, window_time, hop_time, filterbank_cols):
     return (nwin, hop_samples, columns)
 
 
-def gtgram_xe(wave, fs, channels, f_min):
+def gtgram_xe(wave, fs, channels, f_min, f_max):
     """Calculate the intermediate ERB filterbank processed matrix"""
-    cfs = centre_freqs(fs, channels, f_min)
+    cfs = centre_freqs(fs, channels, f_min, f_max)
     fcoefs = np.flipud(make_erb_filters(fs, cfs))
     xf = erb_filterbank(wave, fcoefs)
     xe = np.power(xf, 2)
     return xe
 
 
-def gtgram(wave, fs, window_time, hop_time, channels, f_min):
+def gtgram(wave, fs, window_time, hop_time, channels, f_min, f_max=None):
     """
     Calculate a spectrogram-like time frequency magnitude array based on
     gammatone subband filters. The waveform ``wave`` (at sample rate ``fs``) is
@@ -58,7 +58,7 @@ def gtgram(wave, fs, window_time, hop_time, channels, f_min):
     |
     | (c) 2013 Jason Heeris (Python implementation)
     """
-    xe = gtgram_xe(wave, fs, channels, f_min)
+    xe = gtgram_xe(wave, fs, channels, f_min, f_max)
 
     nwin, hop_samples, ncols = gtgram_strides(fs, window_time, hop_time, xe.shape[1])
     channels, ncols = int(channels), int(ncols)  # typing fro some compatibility reasons

--- a/tests/test_cfs.py
+++ b/tests/test_cfs.py
@@ -21,6 +21,8 @@ from mock import patch
         ((22050, 100, 10), (10, 11025, 100)),
         ((22050, 1000, 100), (100, 11025, 1000)),
         ((160000, 500, 200), (200, 80000, 500)),
+        # add f_max parameter
+        ((22050, 100, 100, 10000), (100, 10000, 100)),
     ),
 )
 def test_centre_freqs(erb_space_mock, args, params):


### PR DESCRIPTION
Hi there, good to see this is on PYPI now. I am transferring this PR from the original repo (https://github.com/detly/gammatone/pull/11) where @Borda already approved it

This adds an `f_max` parameter to `gtgram()`. This parameter was already in the documentation but missing from the implementation.